### PR TITLE
Gyro data output correction

### DIFF
--- a/l3gd20.c
+++ b/l3gd20.c
@@ -374,7 +374,7 @@ void L3GD20_ReadXYZAngRate(float *pfData)
   /* Divide by sensitivity */
   for(i=0; i<3; i++)
   {
-    pfData[i]=(float)(RawData[i] * sensitivity);
+    pfData[i]=(float)(RawData[i] / sensitivity);
   }
 }
 


### PR DESCRIPTION
When reading data from the L3GD20 we should divide by the sensitivity not multiplying by it